### PR TITLE
Text Box focus

### DIFF
--- a/js/thing.js
+++ b/js/thing.js
@@ -124,6 +124,7 @@ function addTextHouse() {
 		addHouse(x);
 	}
 	input.val('');
+	$("#text-input input").focus(); // sets the focus back int the text box 
 }
 
 // add a house at position x


### PR DESCRIPTION
This change puts the focus back in the text box after submitting the form (either by clicking or by pressing enter) to allow for much quicker text entry as it is really irritating to have to keep clicking back in the box.
